### PR TITLE
Fix `Invalid duration` crash on memory diffs with a pivot selected

### DIFF
--- a/frontend/src/RichCell.tsx
+++ b/frontend/src/RichCell.tsx
@@ -21,7 +21,12 @@ function formatTrendChange(trend: Trend, displayMode: TimingDisplayMode): ReactN
   if (displayMode === "absolute" && trend.absoluteDiff) {
     return (
       <>
-        {trend.symbol} <Duration value={trend.absoluteDiff} />
+        {trend.symbol}{" "}
+        {trend.absoluteDiffIsDuration ? (
+          <Duration value={trend.absoluteDiff} />
+        ) : (
+          trend.absoluteDiff
+        )}
       </>
     );
   }

--- a/frontend/src/RichCell.tsx
+++ b/frontend/src/RichCell.tsx
@@ -1,8 +1,8 @@
 import { useAtomValue } from "jotai";
 import type { ReactNode } from "react";
 
-import { type TimingDisplayMode, timingDisplayModeAtom } from "./atoms.ts";
 import { Duration } from "./Duration.tsx";
+import { type TimingDisplayMode, timingDisplayModeAtom } from "./atoms.ts";
 import type { Trend } from "./trends.ts";
 
 export interface RichCellProps {
@@ -61,9 +61,7 @@ export function RichCell({ value, href, bullet, trend, rev }: RichCellProps) {
       <span className="text-base-content/60 text-xs">
         <br />
         {trend && (
-          <span className={trend.colorClass}>
-            {formatTrendChange(trend, timingDisplayMode)}
-          </span>
+          <span className={trend.colorClass}>{formatTrendChange(trend, timingDisplayMode)}</span>
         )}
         {trend && rev && " "}
         {rev && `(${rev})`}

--- a/frontend/src/Timings.tsx
+++ b/frontend/src/Timings.tsx
@@ -125,7 +125,11 @@ function TimingSection({ stepName }: { stepName: StepName }) {
                   titleSecondRowParts.push(uniformRev);
                 }
 
-                const uniformTestRunner = determineUniformTestRunnerForTest(vm, selection, testName);
+                const uniformTestRunner = determineUniformTestRunnerForTest(
+                  vm,
+                  selection,
+                  testName,
+                );
                 titleSecondRowParts.push(
                   <Fragment key="test-runner">
                     <span className="badge badge-sm badge-outline">{uniformTestRunner}</span>
@@ -508,7 +512,10 @@ function findMostVariableMemory(
       return {
         testName,
         postValues: Object.fromEntries(postMap) as Record<ReportTitle, number>,
-        postEditValues: Object.fromEntries(postEditMap.get(testName) ?? []) as Record<ReportTitle, number>,
+        postEditValues: Object.fromEntries(postEditMap.get(testName) ?? []) as Record<
+          ReportTitle,
+          number
+        >,
         variance: v,
       };
     })
@@ -550,7 +557,9 @@ function LsMemorySection() {
                 const pivotValue = pivotReport?.metrics[key] ?? null;
                 const allValues = selectedReports.map((r) => r.metrics[key]);
                 const trend = !isSingleReport && numberTrend(value, pivotValue, allValues);
-                return <RichCell value={value != null ? formatMemoryKB(value) : null} trend={trend} />;
+                return (
+                  <RichCell value={value != null ? formatMemoryKB(value) : null} trend={trend} />
+                );
               }}
             />
           ))}
@@ -587,8 +596,12 @@ function LsMemorySection() {
                               <span className="text-base-content/60">
                                 {" → "}
                                 {formatMemoryKB(postEdit)}
-                                <span className={postEdit - post > 0 ? "text-error" : "text-success"}>
-                                  {" "}({postEdit - post >= 0 ? "+" : ""}{formatMemoryKB(postEdit - post)})
+                                <span
+                                  className={postEdit - post > 0 ? "text-error" : "text-success"}
+                                >
+                                  {" "}
+                                  ({postEdit - post >= 0 ? "+" : ""}
+                                  {formatMemoryKB(postEdit - post)})
                                 </span>
                               </span>
                             )}

--- a/frontend/src/atoms.ts
+++ b/frontend/src/atoms.ts
@@ -274,7 +274,13 @@ export const pivotReportAtom = atom<Report | undefined>((get) => {
   }
 });
 
-export type SectionId = "metrics" | `label-${LabelCategory}` | `timings-${StepName}` | "timings-incremental-build" | "timings-ls-memory" | "downloads";
+export type SectionId =
+  | "metrics"
+  | `label-${LabelCategory}`
+  | `timings-${StepName}`
+  | "timings-incremental-build"
+  | "timings-ls-memory"
+  | "downloads";
 
 export const openSectionsAtom = atomWithStorage<SectionId[] | "all">("maat-open-sections", [
   "metrics",

--- a/frontend/src/trends.ts
+++ b/frontend/src/trends.ts
@@ -29,9 +29,12 @@ export function numberTrend(
   }
 
   const nonNullValues = allValues.filter((v) => v != null) as number[];
-  const minValue = nonNullValues.length > 0 ? nonNullValues.reduce((a, b) => (a < b ? a : b)) : null;
-  const maxValue = nonNullValues.length > 0 ? nonNullValues.reduce((a, b) => (a > b ? a : b)) : null;
-  const isExtreme = (minValue !== null && value === minValue) || (maxValue !== null && value === maxValue);
+  const minValue =
+    nonNullValues.length > 0 ? nonNullValues.reduce((a, b) => (a < b ? a : b)) : null;
+  const maxValue =
+    nonNullValues.length > 0 ? nonNullValues.reduce((a, b) => (a > b ? a : b)) : null;
+  const isExtreme =
+    (minValue !== null && value === minValue) || (maxValue !== null && value === maxValue);
 
   let symbol: string;
   if (ratio < 0) symbol = isExtreme ? "⤓" : "↓";
@@ -51,7 +54,15 @@ export function numberTrend(
 
   const colorClass = ratio < 0 ? "text-success" : ratio > 0 ? "text-error" : "text-base-content/60";
 
-  return { ratio, isExtreme, symbol, percentage, absoluteDiff, absoluteDiffIsDuration: false, colorClass };
+  return {
+    ratio,
+    isExtreme,
+    symbol,
+    percentage,
+    absoluteDiff,
+    absoluteDiffIsDuration: false,
+    colorClass,
+  };
 }
 
 export interface Trend {
@@ -104,11 +115,12 @@ export function durationTrend(
 
   // Find extremes for isExtreme calculation.
   const nonNullValues = allValues.filter((v) => v !== null).map((v) => durationTotalMs(v!));
-  const minValue = nonNullValues.length > 0 ? nonNullValues.reduce((a, b) => (a < b ? a : b)) : null;
-  const maxValue = nonNullValues.length > 0 ? nonNullValues.reduce((a, b) => (a > b ? a : b)) : null;
+  const minValue =
+    nonNullValues.length > 0 ? nonNullValues.reduce((a, b) => (a < b ? a : b)) : null;
+  const maxValue =
+    nonNullValues.length > 0 ? nonNullValues.reduce((a, b) => (a > b ? a : b)) : null;
   const isExtreme =
-    (minValue !== null && valueMs === minValue) ||
-    (maxValue !== null && valueMs === maxValue);
+    (minValue !== null && valueMs === minValue) || (maxValue !== null && valueMs === maxValue);
 
   // Generate symbol.
   let symbol: string;

--- a/frontend/src/trends.ts
+++ b/frontend/src/trends.ts
@@ -51,7 +51,7 @@ export function numberTrend(
 
   const colorClass = ratio < 0 ? "text-success" : ratio > 0 ? "text-error" : "text-base-content/60";
 
-  return { ratio, isExtreme, symbol, percentage, absoluteDiff, colorClass };
+  return { ratio, isExtreme, symbol, percentage, absoluteDiff, absoluteDiffIsDuration: false, colorClass };
 }
 
 export interface Trend {
@@ -60,6 +60,9 @@ export interface Trend {
   symbol: string;
   percentage: string;
   absoluteDiff: string | null;
+  // Whether `absoluteDiff` is an ISO-8601 duration string (and so must be rendered via
+  // `<Duration>`) rather than an already-formatted value such as "+775 MB".
+  absoluteDiffIsDuration: boolean;
   colorClass: string;
 }
 
@@ -151,6 +154,7 @@ export function durationTrend(
     symbol,
     percentage,
     absoluteDiff,
+    absoluteDiffIsDuration: true,
     colorClass,
   };
 }


### PR DESCRIPTION
`RichCell` rendered every trend's `absoluteDiff` through `<Duration>` when the timing display mode is "absolute". But `Trend.absoluteDiff` is overloaded: `durationTrend` produces an ISO-8601 duration string (e.g. "+PT1.5S") that must go through `<Duration>`, while `numberTrend` (used for the LS Memory section) produces an already-formatted value such as "+775 MB". Feeding the latter to `Duration` calls `tinyduration.parse("+775 MB")`, which throws "Invalid duration" and crashes the page.

This reproduces whenever a pivot is selected (so memory cells gain a non-null `absoluteDiff`) and the timing display mode is "absolute" — i.e. the "selecting reports + pivot" combination from the issue. Reproduced against the existing reports: 288 memory-cell renders threw "Invalid duration"; 0 after the fix.

Add `absoluteDiffIsDuration` to `Trend` (true for `durationTrend`, false for `numberTrend`) and only wrap the diff in `<Duration>` when it is a duration; otherwise render it as text.

Closes #102