### PR TITLE
Skip the `ls` step for packages with no Cairo sources

### DIFF
--- a/.github/workflows/experiment.yml
+++ b/.github/workflows/experiment.yml
@@ -131,6 +131,10 @@ jobs:
       packages: read
     runs-on: ubuntu-latest
     needs: plan
+    # Backstop only: per-step timeouts in `maat run-plan` (notably the `ls` step) bound individual
+    # hangs to minutes. This coarse ceiling merely stops a runaway partition from riding to
+    # GitHub's 6h default, and pairs with fail-fast so siblings are cancelled promptly.
+    timeout-minutes: 180
     strategy:
       matrix:
         # Dynamically generated array based on PARTITIONS_COUNT

--- a/src/maat/agent/nodejs/maat-test-ls.ts
+++ b/src/maat/agent/nodejs/maat-test-ls.ts
@@ -28,6 +28,23 @@ import {
 
 const SEPARATOR = "\n==============================";
 
+/** Reads a duration from an env var (any `ms`-parseable string), falling back to `dflt`. */
+function envMs(name: string, dflt: ms.StringValue): number {
+    const value = process.env[name];
+    return value ? ms(value as ms.StringValue) : ms(dflt);
+}
+
+// Per-request timeouts. Every LSP request is raced against these so a wedged CairoLS can never
+// make an `await sendRequest(...)` hang forever (the previous behaviour, which let the whole
+// step hang until CI's 6h ceiling). Overridable via env for tuning and tests.
+const INITIALIZE_TIMEOUT = envMs("MAAT_LS_INITIALIZE_TIMEOUT", "2 minutes");
+const REQUEST_TIMEOUT = envMs("MAAT_LS_REQUEST_TIMEOUT", "60 seconds");
+const SHUTDOWN_TIMEOUT = envMs("MAAT_LS_SHUTDOWN_TIMEOUT", "30 seconds");
+// Independent hard cap on the whole LS run. Must exceed the 20-minute analysis wait plus the
+// request timeouts above so the normal path always finishes first; this only fires if the LS
+// wedges so badly that even shutdown/close never settle.
+const HARD_TIMEOUT = envMs("MAAT_LS_HARD_TIMEOUT", "24 minutes");
+
 const ViewAnalyzedCrates = new RequestType0<{}, {}>("cairo/viewAnalyzedCrates");
 
 interface ServerStatusParams {
@@ -144,7 +161,9 @@ async function openFile(url: string, connection: MessageConnection): Promise<voi
  * Calls `cairo/viewAnalyzedCrates` and console-logs the result.
  */
 async function viewAnalysedCrates(connection: MessageConnection) {
-    const result = await connection.sendRequest(ViewAnalyzedCrates);
+    const result = await withTimeout("viewAnalyzedCrates", REQUEST_TIMEOUT, () =>
+        connection.sendRequest(ViewAnalyzedCrates),
+    );
     console.log(SEPARATOR);
     console.log(result);
 }
@@ -158,7 +177,23 @@ async function withCairoLS(
         stdio: ["pipe", "pipe", "inherit"],
     });
 
+    // Hard wall-clock watchdog, armed here and NOT dependent on `callback` settling. Even with
+    // per-request timeouts, a badly deadlocked LS could leave `connection.dispose()` / process
+    // 'close' hanging; this guarantees the harness process still exits (non-zero) instead of
+    // riding to CI's 6h ceiling.
+    const hardKill = setTimeout(() => {
+        console.error(
+            `${SEPARATOR}\nMAAT_LS_HARD_TIMEOUT after ${ms(HARD_TIMEOUT)}; SIGKILLing CairoLS and exiting.`,
+        );
+        try {
+            serverProcess.kill("SIGKILL");
+        } catch {}
+        process.exit(124);
+    }, HARD_TIMEOUT);
+
+    let closed = false;
     serverProcess.on("close", (code, signal) => {
+        closed = true;
         console.log(SEPARATOR);
         console.log(`CairoLS process exited with code: ${code ?? signal}`);
         if (code != null && code !== 0) {
@@ -167,6 +202,7 @@ async function withCairoLS(
         exitPromise.resolve();
     });
 
+    let callbackError: unknown = undefined;
     try {
         const connection = createMessageConnection(
             new StreamMessageReader(serverProcess.stdout),
@@ -179,16 +215,31 @@ async function withCairoLS(
         } finally {
             connection.dispose();
         }
-    } finally {
-        // Give the LS a moment to exit cleanly after shutdown/exit before force-killing.
-        setTimeout(() => {
-            if (!serverProcess.killed) {
-                serverProcess.kill();
-            }
-        }, ms("3 seconds")).unref();
+    } catch (err) {
+        // Capture and rethrow after we have ensured the server is dead, so a failing callback
+        // still tears the LS down.
+        callbackError = err;
     }
 
-    return await exitPromise.promise;
+    // Escalate: SIGTERM, then SIGKILL if it has not actually exited. Guard on `closed` (real
+    // exit), not `serverProcess.killed` (merely "a signal was sent") — a wedged LS may ignore
+    // SIGTERM. The live ChildProcess handle keeps the event loop alive so these timers fire.
+    setTimeout(() => {
+        if (!closed) serverProcess.kill("SIGTERM");
+    }, ms("3 seconds")).unref();
+    setTimeout(() => {
+        if (!closed) serverProcess.kill("SIGKILL");
+    }, ms("6 seconds")).unref();
+
+    try {
+        await exitPromise.promise;
+    } finally {
+        clearTimeout(hardKill);
+    }
+
+    if (callbackError !== undefined) {
+        throw callbackError;
+    }
 }
 
 function formatMemKB(kb: number): string {
@@ -299,7 +350,9 @@ async function initialize(
     connection.onRequest(RegistrationRequest.method, () => {});
 
     // Send `initialize` request.
-    await connection.sendRequest(InitializeRequest.method, params);
+    await withTimeout("initialize", INITIALIZE_TIMEOUT, () =>
+        connection.sendRequest(InitializeRequest.method, params),
+    );
 
     // Send `initialized` notification.
     await connection.sendNotification(InitializedNotification.method, {});
@@ -310,11 +363,22 @@ async function initialize(
  * @param connection An active MessageConnection to the server
  */
 async function terminate(connection: MessageConnection): Promise<void> {
-    // Send `shutdown` request
-    await connection.sendRequest(ShutdownRequest.method);
+    // Send `shutdown` request. If the LS is wedged and never answers, don't block forever here —
+    // log and fall through to `exit`; the caller's watchdog will force-kill the process.
+    try {
+        await withTimeout("shutdown", SHUTDOWN_TIMEOUT, () =>
+            connection.sendRequest(ShutdownRequest.method),
+        );
+    } catch (err) {
+        console.error(`shutdown request did not complete: ${err}`);
+    }
 
-    // Send `exit` notification
-    await connection.sendNotification(ExitNotification.method);
+    // Send `exit` notification (best-effort).
+    try {
+        await connection.sendNotification(ExitNotification.method);
+    } catch (err) {
+        console.error(`exit notification failed: ${err}`);
+    }
 }
 
 /**
@@ -365,6 +429,33 @@ function timeout(ms: number, operation: string = "operation"): Promise<void> {
     return new Promise((_, reject) =>
         setTimeout(() => reject(new Error(`${operation} timed out`)), ms).unref(),
     );
+}
+
+/** Current wall-clock time as `HH:MM:SS.mmm`, for correlating request traces with LS output. */
+function nowTs(): string {
+    return new Date().toISOString().slice(11, 23);
+}
+
+/**
+ * Runs an LSP operation with a timeout, tracing when it is issued and when it settles.
+ * Rejects (via {@link timeout}) if it does not complete in time — a stuck request means the LS is
+ * not answering, so the caller is expected to tear the server down.
+ */
+async function withTimeout<T>(
+    label: string,
+    timeoutMs: number,
+    op: () => Promise<T>,
+): Promise<T> {
+    const started = Date.now();
+    console.log(`[${nowTs()}] -> ${label}`);
+    try {
+        const result = (await Promise.race([op(), timeout(timeoutMs, label)])) as T;
+        console.log(`[${nowTs()}] <- ${label} (${Date.now() - started}ms)`);
+        return result;
+    } catch (err) {
+        console.error(`[${nowTs()}] !! ${label} did not complete: ${err}`);
+        throw err;
+    }
 }
 
 class DiagnosticsCollector {

--- a/src/maat/agent/nodejs/maat-test-ls.ts
+++ b/src/maat/agent/nodejs/maat-test-ls.ts
@@ -88,10 +88,21 @@ withCairoLS(async (connection, pid) => {
         const allLibCairoFiles = await findAllEntryFiles();
         // Shortest path ≈ root package; its changes cascade into dependents.
         const entryFile = allLibCairoFiles.sort((a, b) => a.length - b.length)[0] ?? null;
-        if (entryFile) {
-            console.log(`Opening ${path2url(entryFile)}`);
-            await openFile(path2url(entryFile), connection);
+
+        if (!entryFile) {
+            // Packages with no Cairo sources (e.g. pure proc-macro crates like `alexandria_macros`)
+            // never open a document, so the LS never starts analysis and `AnalysisFinished` can
+            // never fire. Waiting on it would pointlessly burn the entire analysis timeout and then
+            // report a bogus LS failure, so finish cleanly instead — there is nothing to analyze.
+            console.log(SEPARATOR);
+            console.log("No Cairo entry file (lib.cairo) found; nothing to analyze, skipping LS analysis.");
+            disposeAwaiter();
+            diagnosticsCollector.stop();
+            return;
         }
+
+        console.log(`Opening ${path2url(entryFile)}`);
+        await openFile(path2url(entryFile), connection);
 
         // Wait for project analysis to finish.
         // This is only a safety net against a genuinely hung LS. The cap has to comfortably

--- a/src/maat/model.py
+++ b/src/maat/model.py
@@ -27,6 +27,9 @@ type Severity = Literal["error", "warn"]
 EXIT_RUNNER_SKIPPED = -1
 """Exit code set for steps which were skipped by the runner."""
 
+EXIT_STEP_TIMEOUT = 124
+"""Exit code set for steps whose container exceeded ``Step.timeout`` and was killed."""
+
 
 class Step(BaseModel):
     run: str | list[str]
@@ -48,6 +51,13 @@ class Step(BaseModel):
     workdir: str | None = None
     """
     Working directory for this step. If None, the default working directory is used.
+    """
+    timeout: int | None = None
+    """
+    Maximum wall-clock time in seconds for this step's container. When exceeded, the container
+    is killed and the step is recorded with exit code ``EXIT_STEP_TIMEOUT``. ``None`` (the default)
+    disables the timeout. Set for steps that can hang indefinitely (notably the ``ls`` step, which
+    drives CairoLS and can freeze on heavy proc-macro projects).
     """
     binds: list[list[str]] = Field(default_factory=list, exclude=True)
     """

--- a/src/maat/report/analysis.py
+++ b/src/maat/report/analysis.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import Literal
 
 from maat.model import (
+    EXIT_STEP_TIMEOUT,
     Analyser,
     Label,
     LabelCategory,
@@ -329,6 +330,11 @@ def _ls_label(ls: StepReport, build_failed: bool) -> Label | None:
     Creates a label based on language server diagnostics and build status.
     Returns a label only when there is an inconsistency between build and LS statuses.
     """
+    # A timed-out `ls` step means CairoLS hung (see `Step.timeout` and the `maat-test-ls`
+    # hard cap). Surface it explicitly instead of letting it fall through to a generic error.
+    if ls.exit_code == EXIT_STEP_TIMEOUT:
+        return Label.new(LabelCategory.LS_FAIL, "ls timeout")
+
     has_errors = _ls_has_errors(ls)
 
     if lbl := _fatal_panic(ls, category=LabelCategory.LS_FAIL):

--- a/src/maat/runner/executor.py
+++ b/src/maat/runner/executor.py
@@ -1,18 +1,27 @@
 import os
+import threading
+import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
 from pathlib import Path
+from queue import Empty, Queue
 
 from python_on_whales import DockerClient, DockerException, Image, Volume
 
-from maat.model import EXIT_RUNNER_SKIPPED, Plan, PlanPartitionView, Test
+from maat.model import (
+    EXIT_RUNNER_SKIPPED,
+    EXIT_STEP_TIMEOUT,
+    Plan,
+    PlanPartitionView,
+    Test,
+)
 from maat.report.reporter import Reporter, StepReporter
 from maat.runner.bake_volume import bake_volume
 from maat.runner.cancellation_token import CancellationToken, CancelledException
 from maat.runner.ephemeral_volume import ephemeral_volume
 from maat.sandbox import MAAT_CACHE, MAAT_WORKBENCH
-from maat.utils.log import log, track
+from maat.utils.log import log, track, uptime
 from maat.utils.shell import split_command
 from maat.utils.slugify import slugify
 from maat.utils.unique_id import snowflake_id
@@ -163,6 +172,9 @@ def _execute_test(
                     env=step.env,
                     workdir=step.workdir,
                     extra_binds=step.binds or None,
+                    timeout=step.timeout,
+                    stream_logs=step.timeout is not None
+                    or bool(os.environ.get("MAAT_STREAM_LOGS")),
                 )
 
                 # If this was a setup step, and it failed, mark that we should skip the remaining steps.
@@ -183,6 +195,8 @@ def docker_run_step(
     env: dict[str, str] | None = None,
     workdir: str | None = None,
     extra_binds: list[list[str]] | None = None,
+    timeout: float | None = None,
+    stream_logs: bool = False,
 ) -> int:
     exit_code = 0
 
@@ -222,9 +236,78 @@ def docker_run_step(
             workdir=real_workdir,
             stream=True,
         )
-        for source, line in stream:
-            if step_reporter is not None:
-                step_reporter.log(source, line)
+
+        # Consume the container's output on a helper thread so we can enforce a wall-clock
+        # timeout on it. A plain `for ... in stream` is an unbounded blocking read: a hung
+        # container (e.g. a wedged CairoLS during the `ls` step) would otherwise block this
+        # worker thread — and therefore `pool.shutdown(wait=True)` and the whole partition —
+        # until the CI job's 6h ceiling, with no output flushed.
+        events: Queue = Queue()
+
+        def _pump():
+            try:
+                for source, line in stream:
+                    events.put(("line", source, line))
+                events.put(("done", None, None))
+            except DockerException as exc:
+                events.put(("docker_error", exc, None))
+            except Exception as exc:  # forward any other error to the main thread
+                events.put(("error", exc, None))
+
+        pump_thread = threading.Thread(
+            target=_pump, name=f"maat-pump-{container_name}", daemon=True
+        )
+        pump_thread.start()
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        timed_out = False
+        pending_error: Exception | None = None
+
+        while True:
+            if ct is not None and ct.is_cancelled:
+                # Cancellation kills containers by label elsewhere; stop consuming output.
+                break
+
+            if deadline is None:
+                wait = 1.0
+            else:
+                wait = deadline - time.monotonic()
+                if wait <= 0:
+                    timed_out = True
+                    break
+                wait = min(wait, 1.0)
+
+            try:
+                kind, a, b = events.get(timeout=wait)
+            except Empty:
+                continue
+
+            if kind == "line":
+                source, line = a, b
+                if step_reporter is not None:
+                    step_reporter.log(source, line)
+                if stream_logs:
+                    _tee_line(source, line)
+            elif kind == "done":
+                break
+            else:  # "docker_error" or "error"
+                pending_error = a
+                break
+
+        if timed_out:
+            log(
+                f"⏱️ step exceeded timeout of {timeout:.0f}s, "
+                f"killing container {container_name}"
+            )
+            try:
+                docker.container.kill(container_name)
+            except DockerException:
+                pass  # already gone / not running
+            exit_code = EXIT_STEP_TIMEOUT
+            # Give the pump a moment to drain the tail so the report captures it.
+            pump_thread.join(timeout=30)
+        elif pending_error is not None:
+            raise pending_error
     except DockerException as e:
         exit_code = e.return_code
         if raise_on_nonzero_exit:
@@ -239,6 +322,17 @@ def docker_run_step(
             step_reporter.set_exit_code(exit_code)
 
     return exit_code
+
+
+def _tee_line(source: str, line: bytes) -> None:
+    """Echo a streamed container output line to stdout as it arrives.
+
+    Container output is otherwise only buffered in the report and flushed when the step ends,
+    so a hanging step yields no live trail. Teeing turns silent hangs into a timestamped stream.
+    """
+    tag = "err" if source == "stderr" else "out"
+    text = line.decode("utf-8", errors="replace").rstrip("\n")
+    print(f"[{uptime()}] │ {tag}: {text}", flush=True)
 
 
 def truncate_with_ellipsis(text, max_length):

--- a/src/maat/runner/planner.py
+++ b/src/maat/runner/planner.py
@@ -12,6 +12,12 @@ from maat.utils.docker import image_id
 from maat.utils.semver import is_unstable_semver
 from maat.workspace import Workspace
 
+# Wall-clock cap for the `ls` step's container. CairoLS can freeze on heavy proc-macro projects
+# (see docs and `maat-test-ls`), and the step must never be allowed to hang the whole partition.
+# This is the outer backstop: `maat-test-ls` enforces its own, tighter, in-process hard cap; this
+# value only has to comfortably exceed that so the harness gets a chance to self-report first.
+LS_STEP_TIMEOUT_SECS = 30 * 60
+
 
 def _workflow(project: EcosystemProject, scarb: str) -> list[Step]:
     env: dict[str, str] = {}
@@ -72,17 +78,27 @@ def _workflow(project: EcosystemProject, scarb: str) -> list[Step]:
             },
             workdir=project.workdir,
         ),
-        Step(name="ls", run="maat-test-ls", workdir=project.workdir, env=env),
+        Step(
+            name="ls",
+            run="maat-test-ls",
+            workdir=project.workdir,
+            env=env,
+            timeout=LS_STEP_TIMEOUT_SECS,
+        ),
     ]
 
 
-def inject_local_ls_binary(tests: list[Test], host_path: str, scarb_version: str) -> None:
+def inject_local_ls_binary(
+    tests: list[Test], host_path: str, scarb_version: str
+) -> None:
     """Bind-mount *host_path* over the scarb-cairo-language-server binary inside the container.
 
     Scarb launches its LS extension by path, so replacing the binary at its expected location
     is cleaner than a separate env-var launch path — the SCARB env var is set automatically.
     """
-    container_path = f"/opt/asdf/installs/scarb/{scarb_version}/bin/scarb-cairo-language-server"
+    container_path = (
+        f"/opt/asdf/installs/scarb/{scarb_version}/bin/scarb-cairo-language-server"
+    )
     for test in tests:
         for step in test.steps:
             if step.name == "ls":


### PR DESCRIPTION
Pure proc-macro-definition packages (e.g. `alexandria_macros`) have no `lib.cairo`,
so `maat-test-ls` opens no document, the LS never starts analysis, and
`AnalysisFinished` event never arrives. The harness previously waited out the entire analysis cap and then reported a fail.